### PR TITLE
KDE KF6 update

### DIFF
--- a/org.kde.kanagram.json
+++ b/org.kde.kanagram.json
@@ -21,6 +21,10 @@
         {
             "name": "libkeduvocdocument",
             "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DBUILD_TESTING=OFF",
+                "-DQT_MAJOR_VERSION=6"
+            ],
             "sources": [
                 {
                     "type": "archive",
@@ -33,9 +37,6 @@
                         "url-template": "https://download.kde.org/stable/release-service/$version/src/libkeduvocdocument-$version.tar.xz"
                     }
                 }
-            ],
-            "config-opts": [
-                "-DBUILD_TESTING=OFF"
             ]
         },
         {

--- a/org.kde.kanagram.json
+++ b/org.kde.kanagram.json
@@ -1,7 +1,7 @@
 {
     "id": "org.kde.kanagram",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15-23.08",
+    "runtime-version": "6.6",
     "rename-icon": "kanagram",
     "sdk": "org.kde.Sdk",
     "command": "kanagram",

--- a/org.kde.kanagram.json
+++ b/org.kde.kanagram.json
@@ -24,8 +24,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/libkeduvocdocument-23.08.5.tar.xz",
-                    "sha256": "bdae89c39f063874115235cc69938fbcd3ff83a3d521f4c1ebe67bd32ff39e16",
+                    "url": "https://download.kde.org/stable/release-service/24.02.0/src/libkeduvocdocument-24.02.0.tar.xz",
+                    "sha256": "3c8b4cc555f4f23b77044615cf82cba91ab8676445b5d25c138f96217adde31b",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,
@@ -44,8 +44,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/kdeedu-data-23.08.5.tar.xz",
-                    "sha256": "91da65c109c81ca65b502aa4e4005adbfa3c6aef8f9fa2ed8165c751714f2334",
+                    "url": "https://download.kde.org/stable/release-service/24.02.0/src/kdeedu-data-24.02.0.tar.xz",
+                    "sha256": "0a5d9a90c6147679ff36ccd5d0f8607598e3d89fd13e529ac1d65092ca17ef6f",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,
@@ -61,8 +61,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/kanagram-23.08.5.tar.xz",
-                    "sha256": "9290fc0b47c347ab31fc2b779894d8d5758806c1e6e0f581b7da4f6094d4c304",
+                    "url": "https://download.kde.org/stable/release-service/24.02.0/src/kanagram-24.02.0.tar.xz",
+                    "sha256": "5a0737c24b89d7a4661fbdc9f3435774e3e17bb6db440eb43708d81f4cda8195",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,


### PR DESCRIPTION
Update libkeduvocdocument-23.08.5.tar.xz to 24.02.0
Update kdeedu-data-23.08.5.tar.xz to 24.02.0
Update kanagram-23.08.5.tar.xz to 24.02.0