### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kanagram.json
+++ b/org.kde.kanagram.json
@@ -7,7 +7,8 @@
     "command": "kanagram",
     "cleanup": [
         "/include",
-        "/lib/cmake"
+        "/lib/cmake",
+        "/share/doc"
     ],
     "finish-args": [
         "--share=network",


### PR DESCRIPTION
The installed size reduced from 12.8 MB to 9.9 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.